### PR TITLE
produce shared library instead of module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ if (SPIRV_DISASSEMBLY)
   endif()
 endif()
 
-add_library (opencl-kernel-profiler MODULE src/opencl-kernel-profiler.cpp)
+add_library (opencl-kernel-profiler SHARED src/opencl-kernel-profiler.cpp)
 target_include_directories(opencl-kernel-profiler PUBLIC ${PERFETTO_SDK_PATH})
 if (OPENCL_HEADER_PATH)
   target_include_directories(opencl-kernel-profiler PUBLIC ${OPENCL_HEADER_PATH})


### PR DESCRIPTION
E.g. https://github.com/KhronosGroup/OpenCL-Layers/blob/main/object-lifetime/CMakeLists.txt also uses that. It doesn't matter much on Linux and Windows, but on MacOS currently a `.so` file is produced rather than `.dylib` which is a bit unusual and a bit of a pain to package. I've tested that both versions work though, would you be ok with changing this?